### PR TITLE
Enable support for cursor-line highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Neovim plugin to display both relative and absolute line numbers side-by-side 
 - Configurable format (`abs_rel` or `rel_abs`)
 - Custom separator between numbers
 - Highlight groups for styling relative and absolute numbers
+- Current line highlighting for styling the numbers on the cursor line
 - Lightweight and Lua-only
 
 ![screenshot](https://github.com/user-attachments/assets/ca8dc59b-7ad1-40c4-8a38-09bec8e0c707)
@@ -51,6 +52,8 @@ All the options are optional and below are the defaults.
   separator = " ",
   rel_highlight = { link = "LineNr" },
   abs_highlight = { link = "LineNr" },
+  current_rel_highlight = { link = "CursorLineNr" },
+  current_abs_highlight = { link = "CursorLineNr" },
 }
 ```
 

--- a/doc/line-numbers.txt
+++ b/doc/line-numbers.txt
@@ -9,6 +9,7 @@ using Neovim's `statuscolumn` feature (requires Neovim 0.9+).
 Features:
 - Relative, absolute, both, or none
 - Custom highlights
+- Current line highlighting for styling the numbers on the cursor line
 - Custom separator
 - Lua-only, no dependencies
 
@@ -25,6 +26,8 @@ With lazy.nvim:
         separator = " ",
         rel_highlight = { link = "LineNr" },
         abs_highlight = { link = "LineNr" },
+        current_rel_highlight = { link = "CursorLineNr" },
+        current_abs_highlight = { link = "CursorLineNr" },
       }
     }
 
@@ -39,6 +42,8 @@ With packer.nvim:
             separator = " ",
             rel_highlight = { link = "LineNr" },
             abs_highlight = { link = "LineNr" },
+            current_rel_highlight = { link = "CursorLineNr" },
+            current_abs_highlight = { link = "CursorLineNr" },
         })
       end
     })
@@ -55,6 +60,8 @@ The `setup()` function accepts a table of options:
     separator = " ",
     rel_highlight = { link = "LineNr" },
     abs_highlight = { link = "LineNr" },
+    current_rel_highlight = { link = "CursorLineNr" },
+    current_abs_highlight = { link = "CursorLineNr" },
   })
 
 ==============================================================================

--- a/lua/line-numbers/init.lua
+++ b/lua/line-numbers/init.lua
@@ -15,6 +15,10 @@ M.config = {
   rel_highlight = { link = "LineNr" },
   -- Custom highlight for absolute numbers
   abs_highlight = { link = "LineNr" },
+  -- Custom highlight for current line relative numbers
+  current_rel_highlight = { link = "CursorLineNr" },
+  -- Custom highlight for current line absolute numbers
+  current_abs_highlight = { link = "CursorLineNr" },
 }
 
 -- Function to get the required width for a number
@@ -46,6 +50,7 @@ local function create_statuscolumn_formatter()
     local lnum = vim.v.lnum
     local rnum = math.abs(vim.v.relnum or 0)
     local total = vim.api.nvim_buf_line_count(0)
+    local is_current_line = vim.v.relnum == 0
 
     local abs_w = get_width(total)
     local rel_w = get_width(math.max(1, total - 1))
@@ -53,16 +58,19 @@ local function create_statuscolumn_formatter()
     local mode = M.config.mode
     local format = M.config.format
 
+    local abs_hl = is_current_line and "LineAbsCurrent" or "LineAbs"
+    local rel_hl = is_current_line and "LineRelCurrent" or "LineRel"
+
     if mode == "both" then
       if format == "abs_rel" then
-        return string.format("%%#LineAbs#%" .. abs_w .. "d %%#LineRel#%" .. rel_w .. "d%s", lnum, rnum, sep)
+        return string.format("%%#" .. abs_hl .. "#%" .. abs_w .. "d %%#" .. rel_hl .. "#%" .. rel_w .. "d%s", lnum, rnum, sep)
       else
-        return string.format("%%#LineRel#%" .. rel_w .. "d %%#LineAbs#%" .. abs_w .. "d%s", rnum, lnum, sep)
+        return string.format("%%#" .. rel_hl .. "#%" .. rel_w .. "d %%#" .. abs_hl .. "#%" .. abs_w .. "d%s", rnum, lnum, sep)
       end
     elseif mode == "relative" then
-      return string.format("%%#LineRel#%" .. rel_w .. "d%s", rnum, sep)
-    else -- absolute
-      return string.format("%%#LineAbs#%" .. abs_w .. "d%s", lnum, sep)
+      return string.format("%%#" .. rel_hl .. "#%" .. rel_w .. "d%s", rnum, sep)
+    else
+      return string.format("%%#" .. abs_hl .. "#%" .. abs_w .. "d%s", lnum, sep)
     end
   end
 
@@ -108,6 +116,8 @@ function M.setup(opts)
   -- Setup highlight groups
   vim.api.nvim_set_hl(0, "LineRel", M.config.rel_highlight or { link = "LineNr" })
   vim.api.nvim_set_hl(0, "LineAbs", M.config.abs_highlight or { link = "LineNr" })
+  vim.api.nvim_set_hl(0, "LineRelCurrent", M.config.current_rel_highlight or { link = "CursorLineNr" })
+  vim.api.nvim_set_hl(0, "LineAbsCurrent", M.config.current_abs_highlight or { link = "CursorLineNr" })
 
   -- Create autocommands
   local augroup = vim.api.nvim_create_augroup("LineNumbers", { clear = true })
@@ -117,6 +127,8 @@ function M.setup(opts)
     callback = function()
       vim.api.nvim_set_hl(0, "LineRel", M.config.rel_highlight or { link = "LineNr" })
       vim.api.nvim_set_hl(0, "LineAbs", M.config.abs_highlight or { link = "LineNr" })
+      vim.api.nvim_set_hl(0, "LineRelCurrent", M.config.current_rel_highlight or { link = "CursorLineNr" })
+      vim.api.nvim_set_hl(0, "LineAbsCurrent", M.config.current_abs_highlight or { link = "CursorLineNr" })
     end,
   })
 
@@ -127,7 +139,7 @@ function M.setup(opts)
     end,
   })
 
-  vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
+  vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI", "CursorMoved", "CursorMovedI" }, {
     group = augroup,
     callback = function()
       create_statuscolumn_formatter()


### PR DESCRIPTION
## Add Current Line Highlighting Support

Hi @shrynx. I'm a fan of your plugin, thanks for putting it together! I'd love to enable this plugin to support cursor-line highlighting.

### What's Changed

The line numbers on the cursor line can now be styled differently from the rest. By default, they'll use the `CursorLineNr` highlight group (so they'll match whatever the user's colorscheme does for the current line), but the user can customize them however they want.

### How It Works

The changes check if `vim.v.relnum == 0` to know when we're on the current line, then uses different highlight groups (`LineRelCurrent` and `LineAbsCurrent`) for those numbers. Also added a new autocmd that detects when the user moves/makes edits to move the cursor-line styling to the new correct line. 

### Example Screenshot

![CleanShot 2025-05-25 at 08 01 38](https://github.com/user-attachments/assets/4aa9916c-9263-44f4-b6c2-0c4437e79c84)

### Configuration

These changes add nothing to the default configurations. To customize, the user can do something like this:

```lua
require("line-numbers").setup({
  current_rel_highlight = { fg = "#ff6b6b", bold = true },
  current_abs_highlight = { fg = "#4ecdc4", bold = true },
})
```

### Backwards Compatibility

No breaking changes. Existing configs will work the same. The new changes are only additive.

Let me know if you run into any issues or have suggestions for improvements!