### PR TITLE
feat: add plugin-level enable/disable toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ All the options are optional and below are the defaults.
 
 ```lua
 {
-  enabled = true,     -- initial state: true or false
+  enabled = true,     -- or false to disable by default
   mode = "both",      -- "relative", "absolute", "both", "none"
   format = "abs_rel", -- or "rel_abs"
   separator = " ",
@@ -68,6 +68,9 @@ All the options are optional and below are the defaults.
 - :LineNumberToggleEnabled
 - :LineNumberEnable
 - :LineNumberDisable
+
+> [!NOTE]
+> After disabling, you will need to apply your preferred line number settings (e.g. `vim.opt.number, vim.opt.relativenumber`) since the plugin may override the initial settings of them while being enabled.
 
 ## 📚 Help
 

--- a/README.md
+++ b/README.md
@@ -51,12 +51,19 @@ All the options are optional and below are the defaults.
   mode = "both",      -- "relative", "absolute", "both", "none"
   format = "abs_rel", -- or "rel_abs"
   separator = " ",
+  number_fallback = true,
+  relativenumber_fallback = true,
+  statuscolumn_fallback = "",
   rel_highlight = { link = "LineNr" },
   abs_highlight = { link = "LineNr" },
   current_rel_highlight = { link = "CursorLineNr" },
   current_abs_highlight = { link = "CursorLineNr" },
 }
 ```
+
+- `number_fallback`, `relativenumber_fallback`, and `statuscolumn_fallback`
+  are used only when disabling the plugin for windows whose previous values were
+  not captured.
 
 ## 🔀 Commands
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ All the options are optional and below are the defaults.
 
 ```lua
 {
+  enabled = true,     -- initial state: true or false
   mode = "both",      -- "relative", "absolute", "both", "none"
   format = "abs_rel", -- or "rel_abs"
   separator = " ",
@@ -64,6 +65,9 @@ All the options are optional and below are the defaults.
 - :LineNumberAbsolute
 - :LineNumberBoth
 - :LineNumberNone
+- :LineNumberToggleEnabled
+- :LineNumberEnable
+- :LineNumberDisable
 
 ## 📚 Help
 

--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ All the options are optional and below are the defaults.
 - :LineNumberAbsolute
 - :LineNumberBoth
 - :LineNumberNone
-- :LineNumberToggleEnabled
-- :LineNumberEnable
-- :LineNumberDisable
+- :LineNumberPluginToggle
+- :LineNumberPluginEnable
+- :LineNumberPluginDisable
 
 > [!NOTE]
-> After disabling, you will need to apply your preferred line number settings (e.g. `vim.opt.number, vim.opt.relativenumber`) since the plugin may override the initial settings of them while being enabled.
+> Disabling the plugin restores each tracked window's previous `number`, `relativenumber`, and `statuscolumn` values that are saved when the plugin is enabled.
 
 ## 📚 Help
 

--- a/doc/line-numbers.txt
+++ b/doc/line-numbers.txt
@@ -75,9 +75,12 @@ COMMANDS                                                      *line-numbers-comm
   :LineNumberAbsolute   - Show only absolute numbers
   :LineNumberBoth       - Show both
   :LineNumberNone       - Show none
-  :LineNumberToggleEnabled - Toggle plugin enabled state
-  :LineNumberEnable     - Enable plugin behavior
-  :LineNumberDisable    - Disable plugin behavior
+  :LineNumberPluginToggle - Toggle plugin enabled state
+  :LineNumberPluginEnable - Enable plugin behavior
+  :LineNumberPluginDisable - Disable plugin behavior
+
+Disabling restores each tracked window's previous `number`,
+`relativenumber`, and `statuscolumn` values that are saved when the plugin is enabled.
 
 ==============================================================================
 CREDITS                                                       *line-numbers-credits*

--- a/doc/line-numbers.txt
+++ b/doc/line-numbers.txt
@@ -55,9 +55,9 @@ CONFIGURATION                                                 *line-numbers-conf
 
 The `setup()` function accepts a table of options:
 
-> 
+>
   require("line-numbers").setup({
-    enabled = true,
+    enabled = true,             -- or false to disable by default
     mode = "both",              -- "relative", "absolute", "both", "none"
     format = "abs_rel",         -- or "rel_abs"
     separator = " ",

--- a/doc/line-numbers.txt
+++ b/doc/line-numbers.txt
@@ -21,6 +21,7 @@ With lazy.nvim:
     {
       "shrynx/line-numbers.nvim",
       opts = {
+        enabled = true,
         mode = "both",
         format = "abs_rel",
         separator = " ",
@@ -37,6 +38,7 @@ With packer.nvim:
       "shrynx/line-numbers.nvim",
       config = function()
         require("line-numbers").setup({
+            enabled = true,
             mode = "both",
             format = "abs_rel",
             separator = " ",
@@ -55,6 +57,7 @@ The `setup()` function accepts a table of options:
 
 > 
   require("line-numbers").setup({
+    enabled = true,
     mode = "both",              -- "relative", "absolute", "both", "none"
     format = "abs_rel",         -- or "rel_abs"
     separator = " ",
@@ -72,6 +75,9 @@ COMMANDS                                                      *line-numbers-comm
   :LineNumberAbsolute   - Show only absolute numbers
   :LineNumberBoth       - Show both
   :LineNumberNone       - Show none
+  :LineNumberToggleEnabled - Toggle plugin enabled state
+  :LineNumberEnable     - Enable plugin behavior
+  :LineNumberDisable    - Disable plugin behavior
 
 ==============================================================================
 CREDITS                                                       *line-numbers-credits*

--- a/doc/line-numbers.txt
+++ b/doc/line-numbers.txt
@@ -25,6 +25,9 @@ With lazy.nvim:
         mode = "both",
         format = "abs_rel",
         separator = " ",
+        number_fallback = true,
+        relativenumber_fallback = true,
+        statuscolumn_fallback = "",
         rel_highlight = { link = "LineNr" },
         abs_highlight = { link = "LineNr" },
         current_rel_highlight = { link = "CursorLineNr" },
@@ -42,6 +45,9 @@ With packer.nvim:
             mode = "both",
             format = "abs_rel",
             separator = " ",
+            number_fallback = true,
+            relativenumber_fallback = true,
+            statuscolumn_fallback = "",
             rel_highlight = { link = "LineNr" },
             abs_highlight = { link = "LineNr" },
             current_rel_highlight = { link = "CursorLineNr" },
@@ -61,11 +67,21 @@ The `setup()` function accepts a table of options:
     mode = "both",              -- "relative", "absolute", "both", "none"
     format = "abs_rel",         -- or "rel_abs"
     separator = " ",
+    number_fallback = true,
+    relativenumber_fallback = true,
+    statuscolumn_fallback = "",
     rel_highlight = { link = "LineNr" },
     abs_highlight = { link = "LineNr" },
     current_rel_highlight = { link = "CursorLineNr" },
     current_abs_highlight = { link = "CursorLineNr" },
   })
+
+These fallback options are used only when disabling the plugin for windows
+whose previous values were not captured:
+
+  number_fallback         (default: true)
+  relativenumber_fallback (default: true)
+  statuscolumn_fallback   (default: "")
 
 ==============================================================================
 COMMANDS                                                      *line-numbers-commands*

--- a/lua/line-numbers/init.lua
+++ b/lua/line-numbers/init.lua
@@ -5,6 +5,8 @@ local M = {}
 
 -- Default configuration
 M.config = {
+  -- Initial state of the plugin: true or false
+  enabled = true,
   -- Show mode can be: "relative", "absolute", "both", or "none"
   mode = "both",
   -- Format for numbers: "abs_rel" or "rel_abs"
@@ -26,6 +28,13 @@ local function get_width(num)
   return math.max(1, math.floor(math.log(num, 10)) + 1)
 end
 
+-- Helper to set statuscolumn for all windows
+local function set_statuscolumn_for_all_windows(value)
+  for _, win in ipairs(vim.api.nvim_list_wins()) do
+    vim.wo[win].statuscolumn = value
+  end
+end
+
 -- Internal toggle to keep vim.v.relnum up-to-date
 local function apply_number_settings()
   vim.opt.number = false
@@ -37,7 +46,7 @@ local function apply_number_settings()
 end
 
 -- Function to create statuscolumn formatter
-local function create_statuscolumn_formatter()
+local function create_statuscolumn_formatter(apply_all)
   _G.line_numbers_format = function()
     local ft = vim.bo.filetype
     local bt = vim.bo.buftype
@@ -73,8 +82,11 @@ local function create_statuscolumn_formatter()
       return string.format("%%#" .. abs_hl .. "#%" .. abs_w .. "d%s", lnum, sep)
     end
   end
-
-  vim.opt.statuscolumn = "%s%{%v:lua.line_numbers_format()%}"
+  if apply_all then
+    set_statuscolumn_for_all_windows("%s%{%v:lua.line_numbers_format()%}")
+  else
+    vim.wo.statuscolumn = "%s%{%v:lua.line_numbers_format()%}"
+  end
 end
 
 -- Function to change display mode on the fly
@@ -84,8 +96,10 @@ function M.set_mode(mode)
   end
 
   M.config.mode = mode
-  apply_number_settings()
-  create_statuscolumn_formatter()
+  if M.config.enabled then
+    apply_number_settings()
+    create_statuscolumn_formatter()
+  end
 end
 
 -- Function to toggle between modes
@@ -102,6 +116,33 @@ function M.toggle_mode()
 
   local next_index = current_index % #modes + 1
   M.set_mode(modes[next_index])
+end
+
+function M.toggle_enabled()
+  if M.config.enabled then
+    M.disable()
+  elseif not M.config.enabled then
+    M.enable()
+  end
+end
+
+function M.enable()
+  if M.config.enabled == true then
+    vim.notify("LineNumbers: Already enabled", vim.log.levels.WARN)
+    return
+  end
+  M.config.enabled = true
+  apply_number_settings()
+  create_statuscolumn_formatter(true)
+end
+
+function M.disable()
+  if M.config.enabled == false then
+    vim.notify("LineNumbers: Already disabled", vim.log.levels.WARN)
+    return
+  end
+  M.config.enabled = false
+  set_statuscolumn_for_all_windows("")
 end
 
 -- Setup function to initialize the plugin with user configuration
@@ -135,6 +176,9 @@ function M.setup(opts)
   vim.api.nvim_create_autocmd({ "BufEnter", "WinEnter", "VimResized" }, {
     group = augroup,
     callback = function()
+      if M.config.enabled == false then
+        return
+      end
       apply_number_settings()
     end,
   })
@@ -142,15 +186,20 @@ function M.setup(opts)
   vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI", "CursorMoved", "CursorMovedI" }, {
     group = augroup,
     callback = function()
+      if M.config.enabled == false then
+        return
+      end
       create_statuscolumn_formatter()
     end,
   })
 
-  -- Create the formatter and statuscolumn
-  create_statuscolumn_formatter()
+  if M.config.enabled then
+    -- Create the formatter and statuscolumn
+    create_statuscolumn_formatter()
 
-  -- Apply number settings
-  apply_number_settings()
+    -- Apply number settings
+    apply_number_settings()
+  end
 
   -- Create commands
   vim.api.nvim_create_user_command("LineNumberToggle", function()
@@ -173,8 +222,22 @@ function M.setup(opts)
     M.set_mode("none")
   end, {})
 
+  vim.api.nvim_create_user_command("LineNumberToggleEnabled", function()
+    M.toggle_enabled()
+  end, {})
+
+  vim.api.nvim_create_user_command("LineNumberEnable", function()
+    M.enable()
+  end, {})
+
+  vim.api.nvim_create_user_command("LineNumberDisable", function()
+    M.disable()
+  end, {})
+
   -- Set initial mode
-  M.set_mode(M.config.mode)
+  if M.config.enabled then
+    M.set_mode(M.config.mode)
+  end
 end
 
 return M

--- a/lua/line-numbers/init.lua
+++ b/lua/line-numbers/init.lua
@@ -163,7 +163,7 @@ end
 
 function M.disable_plugin()
   if M.config.enabled == false then
-    vim.notify("LineNumbers: Already disabled, but disable() was called", vim.log.levels.WARN)
+    vim.notify("LineNumbers: Already disabled, but disable_plugin() was called", vim.log.levels.WARN)
     return
   end
   M.config.enabled = false

--- a/lua/line-numbers/init.lua
+++ b/lua/line-numbers/init.lua
@@ -13,6 +13,10 @@ M.config = {
   format = "abs_rel",
   -- Seperator end of line numbers
   separator = " ",
+  -- Fallback options for windows where config weren't preserved
+  number_fallback = true,
+  relativenumber_fallback = true,
+  statuscolumn_fallback = "",
   -- Custom highlight for relative numbers
   rel_highlight = { link = "LineNr" },
   -- Custom highlight for absolute numbers
@@ -166,11 +170,15 @@ function M.disable_plugin()
   if not pcall(vim.api.nvim_del_augroup_by_name, "LineNumbersRuntime") then
     vim.notify("LineNumbers: Failed to remove autocommands, they may still be active", vim.log.levels.WARN)
   end
-  for win in pairs(last_number_columns_config) do
-    if vim.api.nvim_win_is_valid(win) then
+  for _, win in ipairs(vim.api.nvim_list_wins()) do
+    if last_number_columns_config[win] then
       vim.wo[win].number = last_number_columns_config[win].number
       vim.wo[win].relativenumber = last_number_columns_config[win].relativenumber
       vim.wo[win].statuscolumn = last_number_columns_config[win].statuscolumn
+    else
+      vim.wo[win].number = M.config.number_fallback
+      vim.wo[win].relativenumber = M.config.relativenumber_fallback
+      vim.wo[win].statuscolumn = M.config.statuscolumn_fallback
     end
   end
 end

--- a/lua/line-numbers/init.lua
+++ b/lua/line-numbers/init.lua
@@ -147,7 +147,7 @@ end
 
 function M.enable_plugin()
   if M.config.enabled == true then
-    vim.notify("LineNumbers: Already enabled, but enable() was called", vim.log.levels.WARN)
+    vim.notify("LineNumbers: Already enabled, but enable_plugin() was called", vim.log.levels.WARN)
     return
   end
   M.config.enabled = true

--- a/lua/line-numbers/init.lua
+++ b/lua/line-numbers/init.lua
@@ -116,6 +116,9 @@ local function create_runtime_autocmds()
   vim.api.nvim_create_autocmd({ "BufEnter", "WinEnter", "VimResized" }, {
     group = augroup_runtime,
     callback = function()
+      if not M.config.enabled then
+        return
+      end
       apply_number_settings()
     end,
   })
@@ -123,6 +126,9 @@ local function create_runtime_autocmds()
   vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI", "CursorMoved", "CursorMovedI" }, {
     group = augroup_runtime,
     callback = function()
+      if not M.config.enabled then
+        return
+      end
       create_statuscolumn_formatter()
     end,
   })

--- a/lua/line-numbers/init.lua
+++ b/lua/line-numbers/init.lua
@@ -28,13 +28,6 @@ local function get_width(num)
   return math.max(1, math.floor(math.log(num, 10)) + 1)
 end
 
--- Helper to set statuscolumn for all windows
-local function set_statuscolumn_for_all_windows(value)
-  for _, win in ipairs(vim.api.nvim_list_wins()) do
-    vim.wo[win].statuscolumn = value
-  end
-end
-
 -- Internal toggle to keep vim.v.relnum up-to-date
 local function apply_number_settings()
   vim.opt.number = false
@@ -46,7 +39,7 @@ local function apply_number_settings()
 end
 
 -- Function to create statuscolumn formatter
-local function create_statuscolumn_formatter(apply_all)
+local function create_statuscolumn_formatter()
   _G.line_numbers_format = function()
     local ft = vim.bo.filetype
     local bt = vim.bo.buftype
@@ -82,11 +75,7 @@ local function create_statuscolumn_formatter(apply_all)
       return string.format("%%#" .. abs_hl .. "#%" .. abs_w .. "d%s", lnum, sep)
     end
   end
-  if apply_all then
-    set_statuscolumn_for_all_windows("%s%{%v:lua.line_numbers_format()%}")
-  else
-    vim.wo.statuscolumn = "%s%{%v:lua.line_numbers_format()%}"
-  end
+  vim.opt.statuscolumn = "%s%{%v:lua.line_numbers_format()%}"
 end
 
 -- Function to change display mode on the fly
@@ -118,31 +107,72 @@ function M.toggle_mode()
   M.set_mode(modes[next_index])
 end
 
-function M.toggle_enabled()
+local function create_runtime_autocmds()
+  local augroup_runtime = vim.api.nvim_create_augroup("LineNumbersRuntime", { clear = true })
+  vim.api.nvim_create_autocmd({ "BufEnter", "WinEnter", "VimResized" }, {
+    group = augroup_runtime,
+    callback = function()
+      apply_number_settings()
+    end,
+  })
+
+  vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI", "CursorMoved", "CursorMovedI" }, {
+    group = augroup_runtime,
+    callback = function()
+      create_statuscolumn_formatter()
+    end,
+  })
+end
+
+function M.toggle_plugin()
   if M.config.enabled then
-    M.disable()
-  elseif not M.config.enabled then
-    M.enable()
+    M.disable_plugin()
+  else
+    M.enable_plugin()
   end
 end
 
-function M.enable()
+local last_number_columns_config = {}
+
+local function save_last_number_columns_config()
+  last_number_columns_config = {}
+  for _, win in ipairs(vim.api.nvim_list_wins()) do
+    last_number_columns_config[win] = {
+      number = vim.wo[win].number,
+      relativenumber = vim.wo[win].relativenumber,
+      statuscolumn = vim.wo[win].statuscolumn,
+    }
+  end
+end
+
+function M.enable_plugin()
   if M.config.enabled == true then
-    vim.notify("LineNumbers: Already enabled", vim.log.levels.WARN)
+    vim.notify("LineNumbers: Already enabled, but enable() was called", vim.log.levels.WARN)
     return
   end
   M.config.enabled = true
+  create_runtime_autocmds()
+  save_last_number_columns_config()
   apply_number_settings()
-  create_statuscolumn_formatter(true)
+  create_statuscolumn_formatter()
 end
 
-function M.disable()
+function M.disable_plugin()
   if M.config.enabled == false then
-    vim.notify("LineNumbers: Already disabled", vim.log.levels.WARN)
+    vim.notify("LineNumbers: Already disabled, but disable() was called", vim.log.levels.WARN)
     return
   end
   M.config.enabled = false
-  set_statuscolumn_for_all_windows("")
+  if not pcall(vim.api.nvim_del_augroup_by_name, "LineNumbersRuntime") then
+    vim.notify("LineNumbers: Failed to remove autocommands, they may still be active", vim.log.levels.WARN)
+  end
+  for win in pairs(last_number_columns_config) do
+    if vim.api.nvim_win_is_valid(win) then
+      vim.wo[win].number = last_number_columns_config[win].number
+      vim.wo[win].relativenumber = last_number_columns_config[win].relativenumber
+      vim.wo[win].statuscolumn = last_number_columns_config[win].statuscolumn
+    end
+  end
 end
 
 -- Setup function to initialize the plugin with user configuration
@@ -160,11 +190,10 @@ function M.setup(opts)
   vim.api.nvim_set_hl(0, "LineRelCurrent", M.config.current_rel_highlight or { link = "CursorLineNr" })
   vim.api.nvim_set_hl(0, "LineAbsCurrent", M.config.current_abs_highlight or { link = "CursorLineNr" })
 
-  -- Create autocommands
-  local augroup = vim.api.nvim_create_augroup("LineNumbers", { clear = true })
-
+  -- Create a persistent autocommand once
+  local augroup_persistent = vim.api.nvim_create_augroup("LineNumbersPersistent", { clear = true })
   vim.api.nvim_create_autocmd("ColorScheme", {
-    group = augroup,
+    group = augroup_persistent,
     callback = function()
       vim.api.nvim_set_hl(0, "LineRel", M.config.rel_highlight or { link = "LineNr" })
       vim.api.nvim_set_hl(0, "LineAbs", M.config.abs_highlight or { link = "LineNr" })
@@ -173,30 +202,13 @@ function M.setup(opts)
     end,
   })
 
-  vim.api.nvim_create_autocmd({ "BufEnter", "WinEnter", "VimResized" }, {
-    group = augroup,
-    callback = function()
-      if M.config.enabled == false then
-        return
-      end
-      apply_number_settings()
-    end,
-  })
-
-  vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI", "CursorMoved", "CursorMovedI" }, {
-    group = augroup,
-    callback = function()
-      if M.config.enabled == false then
-        return
-      end
-      create_statuscolumn_formatter()
-    end,
-  })
+  save_last_number_columns_config()
 
   if M.config.enabled then
+    -- Create runtime autocommands
+    create_runtime_autocmds()
     -- Create the formatter and statuscolumn
     create_statuscolumn_formatter()
-
     -- Apply number settings
     apply_number_settings()
   end
@@ -222,16 +234,16 @@ function M.setup(opts)
     M.set_mode("none")
   end, {})
 
-  vim.api.nvim_create_user_command("LineNumberToggleEnabled", function()
-    M.toggle_enabled()
+  vim.api.nvim_create_user_command("LineNumberPluginToggle", function()
+    M.toggle_plugin()
   end, {})
 
-  vim.api.nvim_create_user_command("LineNumberEnable", function()
-    M.enable()
+  vim.api.nvim_create_user_command("LineNumberPluginEnable", function()
+    M.enable_plugin()
   end, {})
 
-  vim.api.nvim_create_user_command("LineNumberDisable", function()
-    M.disable()
+  vim.api.nvim_create_user_command("LineNumberPluginDisable", function()
+    M.disable_plugin()
   end, {})
 
   -- Set initial mode


### PR DESCRIPTION
## What
Add a way to enable/disable the plugin from inside Neovim (no need to
remove autocommands externally).

- add `enabled` option (default: `true`)
- add commands:
  :LineNumberPluginToggle - Toggle plugin enabled state
  :LineNumberPluginEnable - Enable plugin behavior
  :LineNumberPluginDisable - Disable plugin behavior
- when disabled, stop plugin updates and clear the plugin `statuscolumn`
- update README and help docs

## Why
I want to use both this plugin and native line numbers, since it has some
additional features. However, toggling the plugin on/off by adding/removing
autocommands is inconvenient and not very safe.