### PR TITLE
Remove redundant statuscolumn refresh autocmd

### DIFF
--- a/lua/line-numbers/init.lua
+++ b/lua/line-numbers/init.lua
@@ -139,13 +139,6 @@ function M.setup(opts)
     end,
   })
 
-  vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI", "CursorMoved", "CursorMovedI" }, {
-    group = augroup,
-    callback = function()
-      create_statuscolumn_formatter()
-    end,
-  })
-
   -- Create the formatter and statuscolumn
   create_statuscolumn_formatter()
 

--- a/lua/line-numbers/init.lua
+++ b/lua/line-numbers/init.lua
@@ -139,6 +139,13 @@ function M.setup(opts)
     end,
   })
 
+  vim.api.nvim_create_autocmd("WinEnter", {
+    group = augroup,
+    callback = function()
+      create_statuscolumn_formatter()
+    end,
+  })
+
   -- Create the formatter and statuscolumn
   create_statuscolumn_formatter()
 


### PR DESCRIPTION
Remove the `TextChanged*`/`CursorMoved*` autocmd that repeatedly reassigns `statuscolumn` for performance improvement. Also, add another autocmd on WinEnter to ensure the statuscolumn is applied on entering other windows.
## Why

- `statuscolumn` expressions are evaluated during redraw for each screen line, so Neovim already recomputes displayed values as needed.
- This plugin's formatter uses dynamic values (`v:lnum`, `v:relnum`, buffer line count), so reassigning `statuscolumn` on every cursor/text event is unnecessary overhead.
- Neovim docs also note that `v:relnum` updates on cursor movement when `relativenumber` is enabled, which this plugin already does for relevant modes.

## Source

> WARNING: this expression is evaluated for each screen line so defining
> an expensive expression can negatively affect render performance.

https://neovim.io/doc/user/options/#'statuscolumn
